### PR TITLE
[QUININE-24] Fix NPE in ReadStats.

### DIFF
--- a/quinine-core/src/main/scala/org/bdgenomics/quinine/metrics/targeted/ReadStats.scala
+++ b/quinine-core/src/main/scala/org/bdgenomics/quinine/metrics/targeted/ReadStats.scala
@@ -200,8 +200,7 @@ private[targeted] object ReadStats extends Serializable {
 
     // how many bases have low quality? convert base qual to ascii first
     val asciiBaseQual = (baseQualThreshold + 33).toChar
-    val lowQualityBases = read.getQual
-      .count(_ < asciiBaseQual)
+    val lowQualityBases = Option(read.getQual).fold(0)(seq => seq.count(_ < asciiBaseQual))
 
     // is this read in a read pair with overlapping inserts?
     // we only care if we are not the first read from the fragment!

--- a/quinine-core/src/test/scala/org/bdgenomics/quinine/metrics/targeted/ReadStatsSuite.scala
+++ b/quinine-core/src/test/scala/org/bdgenomics/quinine/metrics/targeted/ReadStatsSuite.scala
@@ -58,6 +58,11 @@ class ReadStatsSuite extends ADAMFunSuite {
     .setMapq(65)
     .build()
 
+  // similar to the perfect read, but has no qual
+  val noQualRead = AlignmentRecord.newBuilder(perfectRead)
+    .setQual(null)
+    .build()
+
   // similar to the perfect read, but failed the vendor quality checks
   val failedVendorChecksRead = AlignmentRecord.newBuilder(perfectRead)
     .setFailedVendorQualityChecks(true)
@@ -158,6 +163,12 @@ class ReadStatsSuite extends ADAMFunSuite {
 
   test("perfect read") {
     val rs = stat(perfectRead)
+
+    genericAsserts(rs)
+  }
+
+  test("noQualRead should be equivalent to the perfect read, and should not NPE") {
+    val rs = stat(noQualRead)
 
     genericAsserts(rs)
   }


### PR DESCRIPTION
Resolves #24. Wrap quality scores in an Option, so that we don't try to traverse unset quality score strings.