### PR TITLE
[QUININE-28] Fix contamination estimator.

### DIFF
--- a/quinine-core/src/main/scala/org/bdgenomics/quinine/metrics/contamination/ContaminationEstimate.scala
+++ b/quinine-core/src/main/scala/org/bdgenomics/quinine/metrics/contamination/ContaminationEstimate.scala
@@ -63,7 +63,7 @@ case class ContaminationEstimate(testedContaminations: Seq[Double],
   def confidenceWindow(): (Double, Double) = {
 
     // likelihoods above this value are within the 95% confidence window
-    val confidenceLikelihood = mapContaminationEstimate() + log95
+    val confidenceLikelihood = obs.map(_._2).max + log95
 
     // so run a filter to get those points
     val confidentPoints = obs.filter(_._2 >= confidenceLikelihood)
@@ -80,11 +80,11 @@ case class ContaminationEstimate(testedContaminations: Seq[Double],
     val (low, high) = confidenceWindow()
 
     ("Maximum a posteriori contamination estimate: %f\n".format(mapContaminationEstimate) +
-      "95% confidence window: [%2.1f,%2.1f]\n\n".format(low, high) +
+      "95%% confidence window: [%2.1f,%2.1f]\n\n".format(low, high) +
       "Tested contaminations and complete likelihoods:\n" +
       "CONTAM\tLOG L\n" +
       testedContaminations.zip(completeLogLikelihoods)
-      .map(p => "%2.1f\t%0.3f".format(p._1, p._2))
+      .map(p => "%2.1f\t%1.3f".format(p._1, p._2))
       .mkString("\n"))
   }
 }

--- a/quinine-core/src/main/scala/org/bdgenomics/quinine/metrics/contamination/ContaminationEstimator.scala
+++ b/quinine-core/src/main/scala/org/bdgenomics/quinine/metrics/contamination/ContaminationEstimator.scala
@@ -71,6 +71,7 @@ private[contamination] case class ContaminationEstimator(val reads: RDD[Alignmen
    * @return The 'c' which maximizes the likelihood in the grid of possible values.
    */
   def estimateContamination(): ContaminationEstimate = {
+
     val observations = BroadcastRegionJoin.partitionAndJoin(variants.keyBy(_.getRegion),
       reads.keyBy(ReferenceRegion(_)))
       .flatMap(kv => {


### PR DESCRIPTION
* Patch up contamination confidence window logic by comparing against log likelihood instead of contamination estimate.
* Patch formatting strings.

Resolves #28.