### PR TITLE
[QUININE-30] Filter out unmapped reads before Join in ContaminationEstimator

### DIFF
--- a/quinine-core/src/main/scala/org/bdgenomics/quinine/metrics/contamination/ContaminationEstimator.scala
+++ b/quinine-core/src/main/scala/org/bdgenomics/quinine/metrics/contamination/ContaminationEstimator.scala
@@ -73,7 +73,8 @@ private[contamination] case class ContaminationEstimator(val reads: RDD[Alignmen
   def estimateContamination(): ContaminationEstimate = {
 
     val observations = BroadcastRegionJoin.partitionAndJoin(variants.keyBy(_.getRegion),
-      reads.keyBy(ReferenceRegion(_)))
+      reads.filter(_.getReadMapped)
+        .keyBy(ReferenceRegion(_)))
       .flatMap(kv => {
         val (variantSite, read) = kv
         variantSite.toObservation(read)


### PR DESCRIPTION
Resolves #30. Filters on `getReadMapped` prior to joining against VariantSites.