### PR TITLE
[QUININE-31] Check for non-empty RDD in contamination estimator.

### DIFF
--- a/quinine-core/src/main/scala/org/bdgenomics/quinine/metrics/contamination/ContaminationEstimator.scala
+++ b/quinine-core/src/main/scala/org/bdgenomics/quinine/metrics/contamination/ContaminationEstimator.scala
@@ -80,6 +80,14 @@ private[contamination] case class ContaminationEstimator(val reads: RDD[Alignmen
         variantSite.toObservation(read)
       }).cache()
 
+    // count the number of observations and throw an exception if empty
+    // this will also force the rdd into the cache
+    require(observations.count > 0, "%s\n%s\n%s\n%s".format(
+      "Didn't observe any variants that overlapped with reads. Possible causes:",
+      "1. No HomAlt sites in input VCF,",
+      "2. Reads and variants are on different reference builds,",
+      "3. No HomAlt sites had allele frequency annotations."))
+
     // build the grid to search over
     val grid = ((1 until 10).map(i => 0.001 * i) ++
       (1 until 10).map(i => 0.01 * i) ++

--- a/quinine-core/src/test/scala/org/bdgenomics/quinine/metrics/contamination/ContaminationEstimatorSuite.scala
+++ b/quinine-core/src/test/scala/org/bdgenomics/quinine/metrics/contamination/ContaminationEstimatorSuite.scala
@@ -111,6 +111,25 @@ class ContaminationEstimatorSuite extends ADAMFunSuite {
     assert(c > 0.0499 && c < 0.0501)
   }
 
+  sparkTest("estimating contamination with no reads should throw an IAE") {
+    val contaminationVariant = VariantSite(Variant.newBuilder()
+      .setContig(contig)
+      .setStart(100L)
+      .setEnd(101L)
+      .setReferenceAllele("A")
+      .setAlternateAllele("G")
+      .build(), 0.0)
+    val variantRdd = sc.parallelize(Seq(contaminationVariant))
+
+    val readRdd = sc.parallelize(Seq.empty[AlignmentRecord])
+
+    val ce = ContaminationEstimator(readRdd, variantRdd)
+    intercept[IllegalArgumentException] {
+      val c = ce.estimateContamination()
+        .mapContaminationEstimate()
+    }
+  }
+
   def fpLogCompare(a: Double, b: Double, tol: Double = 1e-3): Boolean = {
     val logB = log(b)
     abs(a - logB) <= tol


### PR DESCRIPTION
Resolves #31. There are several common issues with input data that can cause the contamination estimator to try to run a reduce on an empty RDD. We check for a non-empty RDD now, and print a more detailed error message.